### PR TITLE
Rename reserved in php 7 words

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
+.idea
 jimphle-data-structure.iml
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,5 @@
             "name": "Joscha",
             "email": "joscha@schnipseljagd.org"
         }
-    ],
-    "require": {
-
-    }
+    ]
 }

--- a/src/Jimphle/DataStructure/Map.php
+++ b/src/Jimphle/DataStructure/Map.php
@@ -74,7 +74,7 @@ class Map extends Base
     public function setIn($keys, $value)
     {
         $lastKey = array_shift($keys);
-        if (count($keys) > 0 && !isset($this->$lastKey->$keys[0])) {
+        if (count($keys) > 0 && !isset($this->$lastKey->{$keys[0]})) {
             throw new \RuntimeException(sprintf("Key '%s->%s' does not exist.", $lastKey, $keys[0]));
         }
         if (count($keys) > 0 && $this->$lastKey instanceof Map) {

--- a/src/Jimphle/DataStructure/NullObject.php
+++ b/src/Jimphle/DataStructure/NullObject.php
@@ -1,7 +1,7 @@
 <?php
 namespace Jimphle\DataStructure;
 
-class Null extends Base
+class NullObject extends Base
 {
     public function __construct()
     {

--- a/src/Jimphle/DataStructure/Nullable.php
+++ b/src/Jimphle/DataStructure/Nullable.php
@@ -1,7 +1,7 @@
 <?php
 namespace Jimphle\DataStructure;
 
-class NullObject extends Base
+class Nullable extends Base
 {
     public function __construct()
     {

--- a/tests/Jimphle/Test/DataStructure/MapTest.php
+++ b/tests/Jimphle/Test/DataStructure/MapTest.php
@@ -1,9 +1,11 @@
 <?php
+
 namespace Jimphle\Test\DataStructure;
 
+use PHPUnit_Framework_TestCase;
 use Jimphle\DataStructure\Map;
 
-class MapTest extends \PHPUnit_Framework_TestCase
+class MapTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @test
@@ -24,9 +26,9 @@ class MapTest extends \PHPUnit_Framework_TestCase
     public function toArrayShouldWorkRecursively()
     {
         $value = array('foo' => new Map(array('bar' => 'baz')));
-                $payload = new Map(
-                    $value
-                );
+        $payload = new Map(
+            $value
+        );
 
         $this->assertEquals(array('foo' => array('bar' => 'baz')), $payload->toArray());
     }


### PR DESCRIPTION
https://wiki.php.net/rfc/reserve_more_types_in_php_7:

> This RFC does not fully reserve them as keywords; it only prohibits their usage as class, interface and trait names. It also prevents them from being used in namespaces.